### PR TITLE
Employ consistent workflows across the FIREWHEEL ecosystem

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow will enforce FIREWHEEL ecosystem standard linting
 
-name: Linting
+name: FIREWHEEL Linting
 
 on:
   push:
@@ -10,27 +9,5 @@ on:
     branches: [ "main" ]
 
 jobs:
-  lint:
-
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Lint code
-      run: |
-        tox -e lint
-    - name: Lint documentation
-      run: |
-        tox -e lint-docs
+  call-firewheel-linting:
+    uses: sandialabs/firewheel/.github/workflows/linting.yml@main

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,12 +1,6 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+# This workflow will upload a Python package in the official FIREWHEEL ecosystem
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Upload FIREHWEEL Python Package
 
 on:
   release:
@@ -16,24 +10,5 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+  call-firewheel-python-publish:
+    uses: sandialabs/firewheel/.github/workflows/python-publish.yml@main


### PR DESCRIPTION
This converts the workflows for linting and publishing Python packages to employ [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows).

This should allow us to keep things consistent across the FIREWHEEL ecosystem, requiring only updates to the main FIREWHEEL linting/publishing process and having those changes propagate to all the associated model components. 