### PR TITLE
Refer CI to reusable workflows in the FIREWHEEL CI repo

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,6 @@
 # This workflow will enforce FIREWHEEL ecosystem standard linting
 
-name: FIREWHEEL Linting
+name: Lint
 
 on:
   push:
@@ -10,4 +10,8 @@ on:
 
 jobs:
   call-firewheel-linting:
-    uses: sandialabs/firewheel/.github/workflows/linting.yml@main
+    name: FIREHWEEL Linting
+    # Use the FIREWHEEL CI repo for both the workflow and its composite actions
+    uses: sandialabs/firewheel_ci/.github/workflows/linting.yml@main
+    with:
+      actions-ref: main

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,14 +1,15 @@
 # This workflow will upload a Python package in the official FIREWHEEL ecosystem
 
-name: Upload FIREHWEEL Python Package
+name: Publish Python Package
 
 on:
   release:
     types: [published]
 
+jobs:
+  call-firewheel-publishing:
+    name: Publish FIREWHEEL Packages
+    uses: sandialabs/firewheel_ci/.github/workflows/python-publish.yml@main
+
 permissions:
   contents: read
-
-jobs:
-  call-firewheel-python-publish:
-    uses: sandialabs/firewheel/.github/workflows/python-publish.yml@main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,26 +49,9 @@ default:
     - ubuntu1804
 
 stages:
-  - lint
   - deploy
   - upstream
 
-###############################
-# Lint Stages
-#
-# This includes:
-# * lint-code: Linting all executable code
-# * lint-docs: Linting all documentation
-###############################
-lint-code:
-  stage: lint
-  script:
-    - tox -e lint
-
-lint-docs:
-  stage: lint
-  script:
-    - tox -e lint-docs
 
 # Trigger the full FIREWHEEL pipeline (and depend on the result)
 update-docs:


### PR DESCRIPTION
## Overview
This points the CI workfows to the (new) [FIREWHEEL CI repository](https://github.com/sandialabs/firewheel_ci). The functionality should be unchanged from what exists in the base FIREWHEEL repo, but this allows us to version FIREWHEEL and the FIREWHEEL CI independently. 

## Implementation Details

One of the tricky pieces of GItHub CI is that reusable workflows are run as if they are are a part of the calling repository (i.e., the `linting.yml` reusable workflow will run as if it were defined in this repo). This means that workflows defined in the CI repo have no concept of actions defined also defined there (via local reference). [This discussion](https://github.com/orgs/community/discussions/18601) articulates the issue and contains some suggestions, though none of them seem ideal. That said, I've taken a similar approach to one of the suggestions based on what I think best matches our needs. 

For this repository, that means that when we call the `linting.yml` workflow here, we need to do two things:
1. Provide the full path to the CI repo `sandialabs/firewheel_ci/.github/workflows/linting.yml@main`, including the `main` tag; and
2. Provide the CI repo tag (presumably always the same as the workflow tag) because while the `linting.yml` workflow will be checked out from the commit at `main`, it will otherwise have no knowledge that composite actions should also be pulled from that tag.
    - Potentially we use some sort of variable to represent this tag, but I was having trouble with my prelminary attempts to do that based on where variables are allowed/disallowed in GitHub YAML files...

Also, once we get these workflows how we want them, we probably want to release `firewheel_ci` with a tag that we use in place of `main`.