### PR TITLE
Refer CI to additional reusable workflows in the FIREWHEEL CI repo

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-firewheel-linting:
-    name: FIREHWEEL Linting
+    name: FIREWHEEL linting
     # Use the FIREWHEEL CI repo for both the workflow and its composite actions
     uses: sandialabs/firewheel_ci/.github/workflows/linting.yml@main
     with:

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,17 @@
+name: Check Pull Request Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  call-firewheel-pr-title-checker:
+    name: Validate FIREWHEEL PR title
+    uses: sandialabs/firewheel_ci/.github/workflows/pr-title-checker.yml@main
+
+permissions:
+  pull-requests: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-firewheel-publishing:
-    name: Publish FIREWHEEL Packages
+    name: Publish FIREWHEEL packages
     uses: sandialabs/firewheel_ci/.github/workflows/python-publish.yml@main
 
 permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  call-firewheel-release-drafter:
+    name: Update release notes (FIREWHEEL-style)
+    uses: sandialabs/firewheel_ci/.github/workflows/release-drafter.yml@main
+
+permissions:
+  contents: read

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,10 @@
+name: Update Changelog
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  call-firewheel-update-changelog:
+    name: Update Changelog (FIREWHEEL-style)
+    uses: sandialabs/firewheel_ci/.github/workflows/update-changelog.yml@main


### PR DESCRIPTION
## Overview

This extends the CI to include the following workflows (contained in the [FIREWHEEL CI repo](https://github.com/sandialabs/firewheel_ci/)):
- `pr-title-checker.yml`
- `release-drafter.yml`
- `update-changelog.yml`