### PR TITLE
chore: Add MC contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,16 @@
+.. _contributor_guide:
+
+Contributor Guide
+=================
+
+FIREWHEEL is an open source project and we welcome contributions from the community.
+New ideas and better solutions to existing code are always welcome!
+
+As a tool within the FIREWHEEL ecosystem, the FIREWHEEL developers apply the same contribution guidelines and expectations to this model component (MC) as the FIREWHEEL package.
+Those guidelines are detailed completely in the `root FIREWHEEL repository <https://github.com/sandialabs/firewheel/blob/main/CONTRIBUTING.rst>`_.
+
+
+Copyright
+---------
+If you are submitting a patch to the existing codebase, the code will be licensed under the same license as FIREWHEEL (or this MC).
+Please review :ref:`LICENSE <license>` for more information.


### PR DESCRIPTION
I think this should round out the CI changes required for this MC repo (at least for now). 

This MR only adds the new contribution guidelines, but rather than copy them directly from FIREWHEEL, I just kept the intro and the copyright stuff (which seems important to have here) and then just linked to the FIREWHEEL contribution guidelines.

If this is merged, a new release should be drafted and available via the repo homepage. If that release is triggered, ideally the changelog is updated by the CI pipeline (though I obviously couldn't test that for this repo without creating a new release yet... maybe worth trying with like a dev or candidate release if we don't want a full release)