### PR TITLE
ci: Pass `PYPI_API_TOKEN` to reusable workflow explicitly

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,8 @@ jobs:
   call-firewheel-publishing:
     name: Publish FIREWHEEL packages
     uses: sandialabs/firewheel_ci/.github/workflows/python-publish.yml@main
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
 permissions:
   contents: read


### PR DESCRIPTION
I'm not sure if the syntax for this is correct, but it's my current best guess based on what I can see in the [docs](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#calling-a-reusable-workflow).