### PR TITLE
docs(changelog): Remove unreleased section from the Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,20 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/sandialabs/firewheel_repo_base/compare/v2.7.0...v2.8.0
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 ## [2.7.0] - 2024-11-24
 
 This is the initial Open Source release of `firewheel_repo_base`!


### PR DESCRIPTION
It appears that the current way the 'Unreleased' section is implemented, it is not being actively maintained and it is just kinda languishing at the bottom of the `CHANGELOG.md` file. This commit removes that section from the Changelog.

According to [the documentationn](https://github.com/stefanzweifel/php-changelog-updater#expected-changelog-formats), this should not impact the Changelog autoupdater which will continue to add new entries above the highest level-2 heading (`## ...`).

If we do wish to include it, that documentation has guidelines, but I'm not sure how easy it will be to auto-update. My thought is that having unreleased info may not be super necessary in the `CHANGELOG.md` file since this info is already prepared by the CI and available via the GitHub [Releases](https://github.com/sandialabs/firewheel_repo_base/releases) page.