### PR TITLE
feat: Android Support

### DIFF
--- a/src/firewheel_repo_base/minimega/emulated_entities/model_component_objects.py
+++ b/src/firewheel_repo_base/minimega/emulated_entities/model_component_objects.py
@@ -296,17 +296,12 @@ class MinimegaEmulatedVM:
             return {}
 
         # Handle vm_resource communication devices based off VM type
+        virtio_serial_path = os.path.join(fw_config["minimega"]["base_dir"], "namespaces", fw_config["minimega"]["namespace"], self.uuid, "virtio-serial0")
         if minimega_type == "QemuVM":
             qga_config = {
                 "name": "serial",
                 "id": "minimegaqga",
-                "path": os.path.join(
-                    fw_config["minimega"]["base_dir"],
-                    "namespaces",
-                    fw_config["minimega"]["namespace"],
-                    self.uuid,
-                    "virtio-serial0",
-                ),
+                "path": virtio_serial_path,
             }
             self.log.debug("new qga path is %s", qga_config["path"])
             config["aux"]["qga_config"] = qga_config
@@ -315,13 +310,7 @@ class MinimegaEmulatedVM:
         elif minimega_type == "AVD":
             adb_config = {
                 "port": config["aux"]["qemu_append"]["port"],
-                "path": os.path.join(
-                    fw_config["minimega"]["base_dir"],
-                    "namespaces",
-                    fw_config["minimega"]["namespace"],
-                    self.uuid,
-                    "virtio-serial0",
-                ),
+                "path": virtio_serial_path,
             }
             config["aux"]["adb_config"] = adb_config
             return adb_config

--- a/src/firewheel_repo_base/minimega/emulated_entities/model_component_objects.py
+++ b/src/firewheel_repo_base/minimega/emulated_entities/model_component_objects.py
@@ -296,7 +296,13 @@ class MinimegaEmulatedVM:
             return {}
 
         # Handle vm_resource communication devices based off VM type
-        virtio_serial_path = os.path.join(fw_config["minimega"]["base_dir"], "namespaces", fw_config["minimega"]["namespace"], self.uuid, "virtio-serial0")
+        virtio_serial_path = os.path.join(
+            fw_config["minimega"]["base_dir"],
+            "namespaces",
+            fw_config["minimega"]["namespace"],
+            self.uuid,
+            "virtio-serial0",
+        )
         if minimega_type == "QemuVM":
             qga_config = {
                 "name": "serial",
@@ -355,7 +361,6 @@ class MinimegaEmulatedVM:
             if "adb_config" in config["aux"] and config["aux"]["adb_config"]:
                 process_config["path"] = config["aux"]["adb_config"]["path"]
                 process_config["adb_port"] = config["aux"]["adb_config"]["port"]
-            
 
             if "path" not in process_config or "adb_port" not in process_config:
                 return None

--- a/src/firewheel_repo_base/minimega/emulated_entities/model_component_objects.py
+++ b/src/firewheel_repo_base/minimega/emulated_entities/model_component_objects.py
@@ -315,7 +315,6 @@ class MinimegaEmulatedVM:
         elif minimega_type == "AVD":
             adb_config = {
                 "port": config["aux"]["qemu_append"]["port"],
-                # TODO do we even need this, or should we make a conditional for this? I don't think it'll be used...
                 "path": os.path.join(
                     fw_config["minimega"]["base_dir"],
                     "namespaces",

--- a/src/firewheel_repo_base/minimega/parse_experiment_graph/plugin.py
+++ b/src/firewheel_repo_base/minimega/parse_experiment_graph/plugin.py
@@ -87,6 +87,8 @@ class Plugin(AbstractPlugin):
             data[tag_key] = tag_value
 
         # Add any other QEMU options here.
+        if "qemu" in vme_conf["aux"]:
+            data["qemu"] = vme_conf["aux"]["qemu"]
         data["qemu_append"] = vme_conf["aux"]["qemu_append_str"]
 
         # If there's any coscheduling parameters, propagate them
@@ -303,7 +305,12 @@ class Plugin(AbstractPlugin):
             vm_map[vm_name] = vm["hostname"]
 
         def update_socket_path(process_config):
-            original_socket_path = process_config["path"]
+            try:
+                original_socket_path = process_config["path"]
+            except KeyError:
+                # Might not be a QemuVM, ignore this
+                # TODO FIXME better way to handle this?
+                return
             socket_filename = os.path.basename(original_socket_path)
             mm_id = core_vms[process_config["vm_name"]]["id"]
             full_socket_path = os.path.join(mm_api.mm_base, mm_id, socket_filename)

--- a/src/firewheel_repo_base/minimega/parse_experiment_graph/plugin.py
+++ b/src/firewheel_repo_base/minimega/parse_experiment_graph/plugin.py
@@ -305,12 +305,7 @@ class Plugin(AbstractPlugin):
             vm_map[vm_name] = vm["hostname"]
 
         def update_socket_path(process_config):
-            try:
-                original_socket_path = process_config["path"]
-            except KeyError:
-                # Might not be a QemuVM, ignore this
-                # TODO FIXME better way to handle this?
-                return
+            original_socket_path = process_config["path"]
             socket_filename = os.path.basename(original_socket_path)
             mm_id = core_vms[process_config["vm_name"]]["id"]
             full_socket_path = os.path.join(mm_api.mm_base, mm_id, socket_filename)


### PR DESCRIPTION
This helps `base` support emulation of android devices with minimega. It adds VM config parameters for specifying the ADB port that will be used. It also allows a FIREWHEEL model component to overwrite minimega's `qemu` argument (https://sandia-minimega.github.io/#header_4.29) which overwrites the qemu/kvm executable that's used to launch the VMs